### PR TITLE
One Of int64s

### DIFF
--- a/packages/protoc-gen-ng/src/output/types/fields/number-message-field.ts
+++ b/packages/protoc-gen-ng/src/output/types/fields/number-message-field.ts
@@ -68,7 +68,7 @@ export class NumberMessageField implements MessageField {
         _writer.writeRepeated${this.protoDataType}(${this.messageField.number}, _instance.${this.attributeName});
       }`);
     } else if (this.oneOf) {
-      printer.add(`if (_instance.${this.attributeName} || _instance.${this.attributeName} === 0) {
+      printer.add(`if (_instance.${this.attributeName} || _instance.${this.attributeName} === ${this.isStringType ? '\'0\'' : '0'}) {
         _writer.write${this.protoDataType}(${this.messageField.number}, _instance.${this.attributeName});
       }`);
     } else {

--- a/packages/protoc-gen-ng/test/proto/oneof.proto
+++ b/packages/protoc-gen-ng/test/proto/oneof.proto
@@ -1,12 +1,15 @@
 syntax = "proto3";
 
 message OneofTestSub {
-  oneof oneOf { string testString = 1; }
+  oneof oneOf {
+    string testString = 1;
+  }
 }
 
 message OneofTest {
   oneof oneOf {
     string testString = 1;
-    OneofTestSub testMessage = 2;
+    int64 testInt = 2;
+    OneofTestSub testMessage = 3;
   }
 }

--- a/packages/protoc-gen-ng/test/spec/oneof.pb.spec.ts
+++ b/packages/protoc-gen-ng/test/spec/oneof.pb.spec.ts
@@ -24,6 +24,7 @@ describe('data-types.proto', () => {
 
     expect(msg.oneOf).toBe(oneOf.OneofTest.OneOfCase.testString);
     expect(msg.testString).toBe('123');
+    expect(msg.testInt).toBeUndefined();
     expect(msg.testMessage).toBeUndefined();
 
     const message = new oneOf.OneofTestSub();
@@ -35,4 +36,11 @@ describe('data-types.proto', () => {
     expect(msg.testMessage).toBe(message);
   });
 
+  it('should handle int64 correctly', () => {
+    const msg = new oneOf.OneofTest({ testInt: '0' });
+    expect(msg.oneOf).toBe(oneOf.OneofTest.OneOfCase.testInt);
+    expect(msg.testInt).toBe('0');
+    expect(msg.testString).toBeUndefined();
+    expect(msg.testMessage).toBeUndefined();
+  });
 });


### PR DESCRIPTION
Hi,

It appears that the `int64` type isn't handled in `oneof` correctly generating a compilation error:

```sh
 FAIL  packages/protoc-gen-ng/test/spec/oneof.pb.spec.ts
  ● Test suite failed to run

    packages/protoc-gen-ng/test/out/oneof.pb.ts:224:30 - error TS2367: This condition will always return 'false' since the types 'string | undefined' and 'number' have no overlap.

    224     if (_instance.testInt || _instance.testInt === 0) {
                                     ~~~~~~~~~~~~~~~~~~~~~~~
```

Looks like it was just a missing

```typescript
`${this.isStringType ? '\'0\'' : '0'}`
```

in the oneof handling