### PR TITLE
fix(protoc-gen-ng): handle map int64/uin64 key as string

### DIFF
--- a/packages/protoc-gen-ng/src/output/misc/helpers.ts
+++ b/packages/protoc-gen-ng/src/output/misc/helpers.ts
@@ -37,7 +37,7 @@ export function getDataType(proto: Proto, field: ProtoMessageField, options: Get
   if (isFieldMap(proto, field)) {
     const [key, value] = getMapKeyValueFields(proto, field);
 
-    return `{ [prop: ${key.type === ProtoMessageFieldType.string ? 'string' : 'number'}]: ${getDataType(proto, value)}; }`;
+    return `{ [prop: ${key.type === ProtoMessageFieldType.string || isNumberString(key) ? 'string' : 'number'}]: ${getDataType(proto, value)}; }`;
   }
 
   const suffix = !options.ignoreRepeating && field.label === ProtoMessageFieldCardinality.repeated ? '[]' : '';

--- a/packages/protoc-gen-ng/src/output/types/fields/map-message-field.ts
+++ b/packages/protoc-gen-ng/src/output/types/fields/map-message-field.ts
@@ -45,8 +45,8 @@ export class MapMessageField implements MessageField {
     const varName = `_instance.${this.attributeName}`;
     const keysVarName = `keys_${this.messageField.number}`;
     const repeatedVarName = `repeated_${this.messageField.number}`;
-    const isStringKey = ProtoMessageFieldType.string || isNumberString(this.keyField);
-    const castedKey = this.keyField.type === isStringKey ? 'key' : 'Number(key)';
+    const isStringKey = this.keyField.type === ProtoMessageFieldType.string || isNumberString(this.keyField);
+    const castedKey = isStringKey ? 'key' : 'Number(key)';
 
     printer.add(`if (!!${varName}) {
       const ${keysVarName} = Object.keys(${varName} as any);

--- a/packages/protoc-gen-ng/test/spec/data-types.pb.spec.ts
+++ b/packages/protoc-gen-ng/test/spec/data-types.pb.spec.ts
@@ -172,7 +172,7 @@ describe('data-types.proto', () => {
     expect(
       msgWebGrpc
         .getMapInt64SubMap()
-        .get(0)
+        .get(64)
         ?.getString(),
     ).toEqual('someSubString');
     expect(msgWebGrpc.getMapBoolStringMap().get(true)).toEqual('true');


### PR DESCRIPTION
There is an issue with maps that have numeric 64 bit keys.
The `Entry` class is generated correctly, with the `key` being a string, but the map property, getter and setter in the message class are generated with a number key, resulting in the map not being correctly handled by the serializer.

This PR fix this issue, checking the type of the key correctly with the `isNumberString` helper.