### PR TITLE
feat(protoc-gen-ng): add support for custom WKT

### DIFF
--- a/packages/protoc-gen-ng/src/config.ts
+++ b/packages/protoc-gen-ng/src/config.ts
@@ -128,6 +128,10 @@ export class Config {
    */
   public embedWellKnownTypes: boolean;
   /**
+   * Custom well-known type package names
+   */
+  public customWellKnownTypes: {[key: string]: string};
+  /**
    * Per-generated-file-type config
    */
   public files: ConfigFiles;
@@ -147,6 +151,7 @@ export class Config {
   constructor(config: Partial<Config> = {}) {
     this.debug = config.debug ?? false;
     this.embedWellKnownTypes = config.embedWellKnownTypes ?? false;
+    this.customWellKnownTypes = config.customWellKnownTypes ?? {};
     this.files = new ConfigFiles(config.files ?? {});
   }
 

--- a/packages/protoc-gen-ng/src/input/proto.ts
+++ b/packages/protoc-gen-ng/src/input/proto.ts
@@ -145,12 +145,23 @@ export class Proto {
     const root = Array(this.name.split('/').length - 1).fill('..').join('/');
 
     return this.resolved.allDependencies.map(pp => {
-      const isWKT = pp.pb_package === 'google.protobuf';
+      const wktDependency = this.getWktDependency(pp.pb_package);
+      const isWKT = wktDependency != null;
       const genwkt = Services.Config.embedWellKnownTypes;
-      const path = (genwkt || !genwkt && !isWKT) ? `${root || '.'}/${pp.getGeneratedFileBaseName()}` : '@ngx-grpc/well-known-types';
+      const path = (genwkt || !genwkt && !isWKT) ? `${root || '.'}/${pp.getGeneratedFileBaseName()}` : wktDependency;
 
       return `import * as ${this.getDependencyPackageName(pp)} from '${path}';`;
     }).join('\n');
+  }
+
+  getWktDependency(pbPackage: string) {
+    if (pbPackage === 'google.protobuf') {
+      return '@ngx-grpc/well-known-types';
+    }
+    if (!!Services.Config.customWellKnownTypes && !!Services.Config.customWellKnownTypes[pbPackage]) {
+      return Services.Config.customWellKnownTypes[pbPackage];
+    }
+    return null;
   }
 
   getGeneratedFileBaseName() {

--- a/packages/protoc-gen-ng/src/main.ts
+++ b/packages/protoc-gen-ng/src/main.ts
@@ -52,7 +52,8 @@ async function main() {
     const genwkt = Services.Config.embedWellKnownTypes;
 
     protos
-      .filter(p => genwkt || !genwkt && p.pb_package !== 'google.protobuf')
+      .filter(p => genwkt || !genwkt && (p.pb_package !== 'google.protobuf' &&
+        (!Services.Config.customWellKnownTypes || !Services.Config.customWellKnownTypes[p.pb_package])))
       .forEach(proto => {
         Services.Logger.debug(`Start processing proto ${proto.name}`);
 


### PR DESCRIPTION
When using a service like https://buf.build there is no possibility to add custom well known types that are referenced from an import.

Adds the possibility to configure a custom WKT in the protoc-gen-ng config file