### PR TITLE
fix(protoc-gen-ng): old typescript compability

### DIFF
--- a/packages/protoc-gen-ng/src/output/types/fields/enum-message-field.ts
+++ b/packages/protoc-gen-ng/src/output/types/fields/enum-message-field.ts
@@ -114,7 +114,7 @@ export class EnumMessageField implements MessageField {
     if (this.isArray) {
       printer.add(`${this.attributeName}: (this.${this.attributeName} || []).map(v => ${this.notRepeatedDataType}[v]),`);
     } else {
-      printer.add(`${this.attributeName}: ${this.oneOf || this.messageField.proto3Optional ? `this.${this.attributeName} === undefined ? null : ` : ''}${this.notRepeatedDataType}[this.${this.attributeName} ?? 0],`);
+      printer.add(`${this.attributeName}: ${this.oneOf || this.messageField.proto3Optional ? `this.${this.attributeName} === undefined ? null : ` : ''}${this.notRepeatedDataType}[this.${this.attributeName} === null || this.${this.attributeName} === undefined ? 0 : this.${this.attributeName}],`);
     }
   }
 

--- a/packages/protoc-gen-ng/src/output/types/fields/number-message-field.ts
+++ b/packages/protoc-gen-ng/src/output/types/fields/number-message-field.ts
@@ -131,7 +131,11 @@ export class NumberMessageField implements MessageField {
     if (this.isArray) {
       printer.add(`${this.attributeName}: (this.${this.attributeName} || []).slice(),`);
     } else {
-      printer.add(`${this.attributeName}: this.${this.attributeName}${this.oneOf || this.messageField.proto3Optional ? ' ?? null' : ''},`);
+      if (this.oneOf || this.messageField.proto3Optional){
+        printer.add(`${this.attributeName}: this.${this.attributeName} === null || this.${this.attributeName} === undefined ? null : this.${this.attributeName},`);
+      } else {
+        printer.add(`${this.attributeName}: this.${this.attributeName},`);
+      }
     }
   }
 

--- a/packages/protoc-gen-ng/src/output/types/fields/string-message-field.ts
+++ b/packages/protoc-gen-ng/src/output/types/fields/string-message-field.ts
@@ -106,7 +106,11 @@ export class StringMessageField implements MessageField {
     if (this.isArray) {
       printer.add(`${this.attributeName}: (this.${this.attributeName} || []).slice(),`);
     } else {
-      printer.add(`${this.attributeName}: this.${this.attributeName}${this.oneOf || this.messageField.proto3Optional ? ' ?? null' : ''},`);
+      if (this.oneOf || this.messageField.proto3Optional){
+        printer.add(`${this.attributeName}: this.${this.attributeName} === null || this.${this.attributeName} === undefined ? null : this.${this.attributeName},`);
+      } else {
+        printer.add(`${this.attributeName}: this.${this.attributeName},`);
+      }
     }
   }
 


### PR DESCRIPTION
Typescript versions prior to 3.7.0 can't use the coalesce operator.

For supporting old versions of typescript the relevant checks have been changed to an alternative form.