### PR TITLE
fix(protoc-gen-ng): add a @ts-nocheck comment to the generated files

### DIFF
--- a/packages/protoc-gen-ng/src/output/misc/printer.ts
+++ b/packages/protoc-gen-ng/src/output/misc/printer.ts
@@ -33,6 +33,7 @@ export class Printer {
   private createLeadingComment() {
     return `/* tslint:disable */
 /* eslint-disable */
+// @ts-nocheck
 //
 // THIS IS A GENERATED FILE
 // DO NOT MODIFY IT! YOUR CHANGES WILL BE LOST


### PR DESCRIPTION
When the noUnusedLocals tsconfig compiler options is true then unused imports generate  a build error
like 
`Error: projects/testing/src/generated/protos/greet.pbsc.ts:22:1 - error TS6133: 'googleProtobuf000' is declared but its value is never read.`
from the generated line 
`import * as googleProtobuf000 from '@ngx-grpc/well-known-types';`


this is a quick fix - a better solution would be to remove the import if it is not used in that file.