### PR TITLE
fix(grpc-handler): typo in switch-case ( 2x `clientStream`)

### DIFF
--- a/packages/core/src/lib/grpc-handler.ts
+++ b/packages/core/src/lib/grpc-handler.ts
@@ -57,7 +57,7 @@ export class GrpcHandler {
         request.requestClass,
         request.responseClass,
       );
-      case GrpcCallType.clientStream: return request.client.bidiStream(
+      case GrpcCallType.bidiStream: return request.client.bidiStream(
         request.path,
         this.stream(request.requestData),
         request.requestMetadata,


### PR DESCRIPTION
### What

Adjust switch/case of `GrpcHandler.handle()` to check for `GrpcCallType.bidiStream` in last case (@smnbbrv probably just a copy/paste mistake :sweat_smile:?).

### Why

To support `bidiStream`. I was getting the error `Cannot read properties of undefined (reading 'pipe')` because there was no case for when `request.type === GrpcCallType.bidiStream`.