### PR TITLE
fix(protoc-gen-ng): properly generate ID of nested messages

### DIFF
--- a/packages/protoc-gen-ng/src/input/proto-message.ts
+++ b/packages/protoc-gen-ng/src/input/proto-message.ts
@@ -13,6 +13,7 @@ export class ProtoMessage {
   oneofDeclList: ProtoOneof[];
   reservedRangeList: [];
   reservedNameList: [];
+  id: string;
   options: {
     messageSetWireFormat: boolean;
     noStandardDescriptorAccessor: boolean;
@@ -31,6 +32,7 @@ export class ProtoMessage {
     this.oneofDeclList = (value.oneofDeclList || []).map(d => new ProtoOneof(d));
     this.reservedRangeList = value.reservedRangeList;
     this.reservedNameList = value.reservedNameList;
+    this.id = value.id;
     this.options = value.options || {};
   }
 

--- a/packages/protoc-gen-ng/src/input/proto.ts
+++ b/packages/protoc-gen-ng/src/input/proto.ts
@@ -57,6 +57,7 @@ export class Proto {
     const indexMessages = (path: string, submessages: ProtoMessage[]) => {
       submessages.forEach(message => {
         const fullname = path + '.' + message.name;
+        message.id = fullname.substring(1);
 
         this.messageIndex.set(fullname, {
           proto: this,

--- a/packages/protoc-gen-ng/src/output/types/message.ts
+++ b/packages/protoc-gen-ng/src/output/types/message.ts
@@ -123,8 +123,7 @@ export class Message {
       ExternalDependencies.RecursivePartial,
     );
 
-    const messageId = (this.proto.pb_package ? this.proto.pb_package + '.' : '') + this.message.name;
-    let constructorComment = `Message implementation for ${messageId}`;
+    let constructorComment = `Message implementation for ${this.message.id}`;
     if (this.isWkt) {
       if (this.proto.pb_package === 'google.protobuf') {
         constructorComment = 'Well known type, more at https://developers.google.com/protocol-buffers/docs/reference/google.protobuf';
@@ -141,7 +140,7 @@ export class Message {
      */
     export class ${this.message.name} implements GrpcMessage {
 
-      static id = '${messageId}';
+      static id = '${this.message.id}';
 
       /**
        * Deserialize binary data to message


### PR DESCRIPTION
Static id for nested messages are generated incorrectly. 

Let's assume we have the structure like the one below:
```
message Foo{
  uint32 value = 1;
  message Bar {
    uint32 value = 1;
  }
}
```
In this case for `Bar` the id the protoc-gen-ng generates is: `{pb_package}.Bar` but it should be `{pb_package}.Foo.Bar`.

Because of that it is impossible to correctly unmarshal this struct from `google.protobuf.Any` field.
This PR fixes it. Questions, suggestions and remarks are welcomed.

