### PR TITLE
fix(protoc-gen-ng): properties are always generated in optional interfaces

### DIFF
--- a/packages/protoc-gen-ng/src/output/types/fields/abstract-message-field.ts
+++ b/packages/protoc-gen-ng/src/output/types/fields/abstract-message-field.ts
@@ -1,0 +1,64 @@
+import { Proto } from '../../../input/proto';
+import { ProtoMessage } from '../../../input/proto-message';
+import { ProtoMessageField } from '../../../input/proto-message-field';
+import { camelizeSafe } from '../../../utils';
+import { getDataType } from '../../misc/helpers';
+import { Printer } from '../../misc/printer';
+import { MessageField } from '../message-field';
+import { OneOf } from '../oneof';
+
+export abstract class AbstractMessageField implements MessageField {
+  protected attributeName: string;
+  protected dataType: string;
+
+  constructor(
+    protected proto: Proto,
+    protected message: ProtoMessage,
+    protected messageField: ProtoMessageField,
+    protected oneOf?: OneOf,
+  ) {
+    this.attributeName = camelizeSafe(this.messageField.name);
+    this.dataType = getDataType(this.proto, this.messageField);
+  }
+
+  get postfixProp(): string {
+   return this.messageField.proto3Optional ? '?' : '';
+  }
+
+  get type(): string {
+    return this.messageField.proto3Optional ? `${this.dataType} | undefined` : this.dataType;
+  }
+
+  abstract printDeserializeBinaryFromReader(printer: Printer): void;
+
+  abstract printSerializeBinaryToWriter(printer: Printer): void;
+
+  printPrivateAttribute(printer: Printer): void {
+    printer.add(`private _${this.attributeName}${this.postfixProp}: ${this.dataType};`);
+  }
+
+  abstract printInitializer(printer: Printer): void;
+
+  abstract printDefaultValueSetter(printer: Printer): void;
+
+  printGetter(printer: Printer) {
+    printer.add(`get ${this.attributeName}(): ${this.type} { return this._${this.attributeName} }`);
+  }
+
+  printSetter(printer: Printer) {
+    printer.add(`set ${this.attributeName}(value${this.postfixProp}: ${this.dataType}) {
+      ${this.oneOf ? this.oneOf.createFieldSetterAddon(this.messageField) : ''}
+      this._${this.attributeName} = value;
+    }`);
+  }
+
+  abstract printToObjectMapping(printer: Printer): void;
+
+  printAsObjectMapping(printer: Printer): void {
+    printer.add(`${this.attributeName}${this.postfixProp}: ${this.dataType};`);
+  }
+
+  abstract printToProtobufJSONMapping(printer: Printer): void;
+
+  abstract printAsJSONMapping(printer: Printer): void;
+}

--- a/packages/protoc-gen-ng/src/output/types/fields/boolean-message-field.ts
+++ b/packages/protoc-gen-ng/src/output/types/fields/boolean-message-field.ts
@@ -2,29 +2,26 @@ import { Proto } from '../../../input/proto';
 import { ProtoMessage } from '../../../input/proto-message';
 import { ProtoMessageField } from '../../../input/proto-message-field';
 import { ProtoMessageFieldCardinality } from '../../../input/types';
-import { camelizeSafe } from '../../../utils';
-import { getDataType, isPacked } from '../../misc/helpers';
+import { isPacked } from '../../misc/helpers';
 import { Printer } from '../../misc/printer';
-import { MessageField } from '../message-field';
 import { OneOf } from '../oneof';
+import { AbstractMessageField } from './abstract-message-field';
 
-export class BooleanMessageField implements MessageField {
+export class BooleanMessageField extends AbstractMessageField {
 
-  private attributeName: string;
-  private dataType: string;
   private isArray: boolean;
   private isPacked: boolean;
 
   constructor(
-    private proto: Proto,
-    private message: ProtoMessage,
-    private messageField: ProtoMessageField,
-    private oneOf?: OneOf,
+    override proto: Proto,
+    override message: ProtoMessage,
+    override messageField: ProtoMessageField,
+    override oneOf?: OneOf,
   ) {
-    this.attributeName = camelizeSafe(this.messageField.name);
+    super(proto, message, messageField, oneOf);
+
     this.isArray = this.messageField.label === ProtoMessageFieldCardinality.repeated;
     this.isPacked = isPacked(this.proto, this.messageField);
-    this.dataType = getDataType(this.proto, this.messageField);
   }
 
   printDeserializeBinaryFromReader(printer: Printer) {
@@ -63,10 +60,6 @@ export class BooleanMessageField implements MessageField {
     }
   }
 
-  printPrivateAttribute(printer: Printer) {
-    printer.add(`private _${this.attributeName}?: ${this.dataType};`);
-  }
-
   printInitializer(printer: Printer) {
     if (this.isArray) {
       printer.add(`this.${this.attributeName} = (_value.${this.attributeName} || []).slice();`);
@@ -85,27 +78,12 @@ export class BooleanMessageField implements MessageField {
     }
   }
 
-  printGetter(printer: Printer) {
-    printer.add(`get ${this.attributeName}(): ${this.dataType} | undefined { return this._${this.attributeName} }`);
-  }
-
-  printSetter(printer: Printer) {
-    printer.add(`set ${this.attributeName}(value: ${this.dataType} | undefined) {
-      ${this.oneOf ? this.oneOf.createFieldSetterAddon(this.messageField) : ''}
-      this._${this.attributeName} = value;
-    }`);
-  }
-
   printToObjectMapping(printer: Printer) {
     if (this.isArray) {
       printer.add(`${this.attributeName}: (this.${this.attributeName} || []).slice(),`);
     } else {
       printer.add(`${this.attributeName}: this.${this.attributeName},`);
     }
-  }
-
-  printAsObjectMapping(printer: Printer) {
-    printer.add(`${this.attributeName}?: ${this.dataType};`);
   }
 
   printToProtobufJSONMapping(printer: Printer) {
@@ -119,7 +97,7 @@ export class BooleanMessageField implements MessageField {
   }
 
   printAsJSONMapping(printer: Printer) {
-    printer.add(`${this.attributeName}?: ${this.dataType}${this.messageField.proto3Optional ? ' | null' : ''};`);
+    printer.add(`${this.attributeName}: ${this.dataType}${this.messageField.proto3Optional ? ' | null' : ''};`);
   }
 
 }

--- a/packages/protoc-gen-ng/src/output/types/fields/message-message-field.ts
+++ b/packages/protoc-gen-ng/src/output/types/fields/message-message-field.ts
@@ -57,6 +57,10 @@ export class MessageMessageField extends AbstractMessageField {
     }
   }
 
+  printPrivateAttribute(printer: Printer) {
+    printer.add(`private _${this.attributeName}?: ${this.dataType};`);
+  }
+
   printInitializer(printer: Printer) {
     if (this.isArray) {
       printer.add(`this.${this.attributeName} = (_value.${this.attributeName} || []).map(m => new ${this.messageClassName}(m));`);
@@ -75,6 +79,17 @@ export class MessageMessageField extends AbstractMessageField {
     }
   }
 
+  printGetter(printer: Printer) {
+    printer.add(`get ${this.attributeName}(): ${this.dataType} | undefined { return this._${this.attributeName} }`);
+  }
+
+  printSetter(printer: Printer) {
+    printer.add(`set ${this.attributeName}(value: ${this.dataType} | undefined) {
+      ${this.oneOf ? this.oneOf.createFieldSetterAddon(this.messageField) : ''}
+      this._${this.attributeName} = value;
+    }`);
+  }
+
   printToObjectMapping(printer: Printer) {
     if (this.isArray) {
       printer.add(`${this.attributeName}: (this.${this.attributeName} || []).map(m => m.toObject()),`);
@@ -84,7 +99,7 @@ export class MessageMessageField extends AbstractMessageField {
   }
 
   printAsObjectMapping(printer: Printer) {
-    printer.add(`${this.attributeName}${this.postfixProp}: ${this.asObjectDataType};`);
+    printer.add(`${this.attributeName}?: ${this.asObjectDataType};`);
   }
 
   printToProtobufJSONMapping(printer: Printer) {

--- a/packages/protoc-gen-ng/src/output/types/fields/number-message-field.ts
+++ b/packages/protoc-gen-ng/src/output/types/fields/number-message-field.ts
@@ -2,31 +2,28 @@ import { Proto } from '../../../input/proto';
 import { ProtoMessage } from '../../../input/proto-message';
 import { ProtoMessageField } from '../../../input/proto-message-field';
 import { ProtoMessageFieldCardinality, ProtoMessageFieldType } from '../../../input/types';
-import { camelizeSafe } from '../../../utils';
-import { getDataType, isNumberString, isPacked } from '../../misc/helpers';
+import { isNumberString, isPacked } from '../../misc/helpers';
 import { Printer } from '../../misc/printer';
-import { MessageField } from '../message-field';
 import { OneOf } from '../oneof';
+import { AbstractMessageField } from './abstract-message-field';
 
-export class NumberMessageField implements MessageField {
+export class NumberMessageField extends AbstractMessageField {
 
-  private attributeName: string;
-  private dataType: string;
   private isPacked: boolean;
   private protoDataType: string; // used in reader and writer as part of the method call
   private isArray: boolean;
   private isStringType: boolean;
 
   constructor(
-    private proto: Proto,
-    private message: ProtoMessage,
-    private messageField: ProtoMessageField,
-    private oneOf?: OneOf,
+    override proto: Proto,
+    override message: ProtoMessage,
+    override messageField: ProtoMessageField,
+    override oneOf?: OneOf,
   ) {
-    this.attributeName = camelizeSafe(this.messageField.name);
+    super(proto, message, messageField, oneOf);
+
     this.isArray = this.messageField.label === ProtoMessageFieldCardinality.repeated;
     this.isPacked = isPacked(this.proto, this.messageField);
-    this.dataType = getDataType(this.proto, this.messageField);
     this.isStringType = isNumberString(this.messageField);
 
     switch (this.messageField.type) {
@@ -82,10 +79,6 @@ export class NumberMessageField implements MessageField {
     }
   }
 
-  printPrivateAttribute(printer: Printer) {
-    printer.add(`private _${this.attributeName}?: ${this.dataType};`);
-  }
-
   printInitializer(printer: Printer) {
     if (this.isArray) {
       printer.add(`this.${this.attributeName} = (_value.${this.attributeName} || []).slice();`);
@@ -104,27 +97,12 @@ export class NumberMessageField implements MessageField {
     }
   }
 
-  printGetter(printer: Printer) {
-    printer.add(`get ${this.attributeName}(): ${this.dataType} | undefined { return this._${this.attributeName} }`);
-  }
-
-  printSetter(printer: Printer) {
-    printer.add(`set ${this.attributeName}(value: ${this.dataType} | undefined) {
-      ${this.oneOf ? this.oneOf.createFieldSetterAddon(this.messageField) : ''}
-      this._${this.attributeName} = value;
-    }`);
-  }
-
   printToObjectMapping(printer: Printer) {
     if (this.isArray) {
       printer.add(`${this.attributeName}: (this.${this.attributeName} || []).slice(),`);
     } else {
       printer.add(`${this.attributeName}: this.${this.attributeName},`);
     }
-  }
-
-  printAsObjectMapping(printer: Printer) {
-    printer.add(`${this.attributeName}?: ${this.dataType};`);
   }
 
   printToProtobufJSONMapping(printer: Printer) {
@@ -140,7 +118,7 @@ export class NumberMessageField implements MessageField {
   }
 
   printAsJSONMapping(printer: Printer) {
-    printer.add(`${this.attributeName}?: ${this.dataType}${this.oneOf || this.messageField.proto3Optional ? ' | null' : ''};`);
+    printer.add(`${this.attributeName}: ${this.dataType}${this.oneOf || this.messageField.proto3Optional ? ' | null' : ''};`);
   }
 
 }

--- a/packages/protoc-gen-ng/src/output/types/fields/string-message-field.ts
+++ b/packages/protoc-gen-ng/src/output/types/fields/string-message-field.ts
@@ -2,27 +2,23 @@ import { Proto } from '../../../input/proto';
 import { ProtoMessage } from '../../../input/proto-message';
 import { ProtoMessageField } from '../../../input/proto-message-field';
 import { ProtoMessageFieldCardinality } from '../../../input/types';
-import { camelizeSafe } from '../../../utils';
-import { getDataType } from '../../misc/helpers';
 import { Printer } from '../../misc/printer';
-import { MessageField } from '../message-field';
 import { OneOf } from '../oneof';
+import { AbstractMessageField } from './abstract-message-field';
 
-export class StringMessageField implements MessageField {
+export class StringMessageField extends AbstractMessageField {
 
-  private attributeName: string;
-  private dataType: string;
   private isArray: boolean;
 
   constructor(
-    private proto: Proto,
-    private message: ProtoMessage,
-    private messageField: ProtoMessageField,
-    private oneOf?: OneOf,
+    override proto: Proto,
+    override message: ProtoMessage,
+    override messageField: ProtoMessageField,
+    override oneOf?: OneOf,
   ) {
-    this.attributeName = camelizeSafe(this.messageField.name);
+    super(proto, message, messageField, oneOf);
+
     this.isArray = this.messageField.label === ProtoMessageFieldCardinality.repeated;
-    this.dataType = getDataType(this.proto, this.messageField);
   }
 
   printDeserializeBinaryFromReader(printer: Printer) {
@@ -57,10 +53,6 @@ export class StringMessageField implements MessageField {
     }
   }
 
-  printPrivateAttribute(printer: Printer) {
-    printer.add(`private _${this.attributeName}?: ${this.dataType};`);
-  }
-
   printInitializer(printer: Printer) {
     if (this.isArray) {
       printer.add(`this.${this.attributeName} = (_value.${this.attributeName} || []).slice();`);
@@ -79,27 +71,12 @@ export class StringMessageField implements MessageField {
     }
   }
 
-  printGetter(printer: Printer) {
-    printer.add(`get ${this.attributeName}(): ${this.dataType} | undefined { return this._${this.attributeName} }`);
-  }
-
-  printSetter(printer: Printer) {
-    printer.add(`set ${this.attributeName}(value: ${this.dataType} | undefined) {
-      ${this.oneOf ? this.oneOf.createFieldSetterAddon(this.messageField) : ''}
-      this._${this.attributeName} = value;
-    }`);
-  }
-
   printToObjectMapping(printer: Printer) {
     if (this.isArray) {
       printer.add(`${this.attributeName}: (this.${this.attributeName} || []).slice(),`);
     } else {
       printer.add(`${this.attributeName}: this.${this.attributeName},`);
     }
-  }
-
-  printAsObjectMapping(printer: Printer) {
-    printer.add(`${this.attributeName}?: ${this.dataType};`);
   }
 
   printToProtobufJSONMapping(printer: Printer) {
@@ -115,7 +92,6 @@ export class StringMessageField implements MessageField {
   }
 
   printAsJSONMapping(printer: Printer) {
-    printer.add(`${this.attributeName}?: ${this.dataType}${this.oneOf || this.messageField.proto3Optional ? ' | null' : ''};`);
+    printer.add(`${this.attributeName}: ${this.dataType}${this.oneOf || this.messageField.proto3Optional ? ' | null' : ''};`);
   }
-
 }


### PR DESCRIPTION

Values are not optional.

```
  export interface AsObject {
    message?: string;
    shouldThrow?: boolean;
    timestamp?: googleProtobuf000.Timestamp.AsObject;
  }
```
proto3

```
message EchoRequest {
  string message = 1;
  bool shouldThrow = 2;
  google.protobuf.Timestamp timestamp = 3;
}
```

This PR fixes it. Questions, suggestions and remarks are welcomed.