### PR TITLE
Support stripping enums prefixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,6 +326,41 @@ This will change all import statements that reference a message of the package `
 
 If the `embedWellKnownTypes` configuration is enabled, the `customWellKnownTypes` configuration will be ignored and the messages will be generated as usual.
 
+### Stripping Enum prefixes
+
+```js
+module.exports = {
+  stripEnumPrefixes: true
+}
+```
+
+This will strip the type name from the generated enum values.
+
+```proto
+enum SomeEnum {
+	SOME_ENUM_UNSPECIFIED = 0;
+	SOME_ENUM_VALUE1 =1;
+	SOME_ENUM_VALUE2 = 2;
+}
+```
+When `stripEnumPrefixes` is `false` this wil result in.
+```ts
+export enum SomeEnum {
+	SOME_ENUM_UNSPECIFIED = 0,
+	SOME_ENUM_VALUE1 =1,
+	SOME_ENUM_VALUE2 = 2,
+}
+```
+with the feature turned on the result will be the following:
+
+```ts
+export enum SomeEnum {
+	UNSPECIFIED = 0,
+	VALUE1 =1,
+	VALUE2 = 2,
+}
+```
+
 ### Interceptors
 
 You can add global interceptors to all gRPC calls like Angular's built-in `HttpClient` interceptors.

--- a/packages/protoc-gen-ng/ngx-grpc.conf.js
+++ b/packages/protoc-gen-ng/ngx-grpc.conf.js
@@ -1,6 +1,7 @@
 module.exports = {
   debug: true,
   embedWellKnownTypes: true,
+  stripEnumPrefixes: false,
   files: {
     pb: {
       generate: true,

--- a/packages/protoc-gen-ng/src/config.ts
+++ b/packages/protoc-gen-ng/src/config.ts
@@ -10,6 +10,7 @@ All default values look like
 module.exports = {
   debug: false,
   embedWellKnownTypes: false,
+  stripEnumPrefixes: false,
   files: {
     pb: {
       generate: true,
@@ -135,6 +136,11 @@ export class Config {
    * Per-generated-file-type config
    */
   public files: ConfigFiles;
+  /**
+   * This strips enum prefixes (the enum type name + '_') from enum values.
+   * By default false
+   */
+  public stripEnumPrefixes: boolean;
 
   static fromParameter(parameter: string) {
     const params = (parameter || '').split(',').map(p => p.split('=')).reduce((r, p) => ({ ...r, [p[0]]: p[1] }), {}) as {
@@ -153,6 +159,7 @@ export class Config {
     this.embedWellKnownTypes = config.embedWellKnownTypes ?? false;
     this.customWellKnownTypes = config.customWellKnownTypes ?? {};
     this.files = new ConfigFiles(config.files ?? {});
+    this.stripEnumPrefixes = config.stripEnumPrefixes ?? false;
   }
 
 }

--- a/packages/protoc-gen-ng/src/output/types/enum.ts
+++ b/packages/protoc-gen-ng/src/output/types/enum.ts
@@ -1,6 +1,7 @@
 import { Proto } from '../../input/proto';
 import { ProtoEnum } from '../../input/proto-enum';
-import { classify, preserveCaseSafe } from '../../utils';
+import { Services } from '../../services';
+import { classify, preserveCaseSafe, pascalize } from '../../utils';
 import { Printer } from '../misc/printer';
 
 export class Enum {
@@ -11,8 +12,18 @@ export class Enum {
   ) { }
 
   print(printer: Printer) {
+    let enumName = pascalize(this.protoEnum.name)+'_';
+
+    function process(v: {name: string, number: number}) {
+      if ((!!Services.Config.stripEnumPrefixes) && v.name.startsWith(enumName)) {
+        v.name = v.name.substring(enumName.length);
+      }
+
+      return `${preserveCaseSafe(v.name)} = ${v.number}`;
+    }
+
     printer.add(`export enum ${classify(this.protoEnum.name)} {
-      ${this.protoEnum.valueList.map(v => `${preserveCaseSafe(v.name)} = ${v.number}`).join(',')}
+      ${this.protoEnum.valueList.map(process).join(',')}
     }`);
   }
 


### PR DESCRIPTION
This matches the behavior of say the C# generators in `protoc`. And given that in the newer editions they seem to be enforcing this prefixing in enums, it would be a great feature to reduce the amount of stuff you have to type when using the generated types. We have been using this on the 3.1.2 version for a couple of years now.

Fixes #112 